### PR TITLE
INTG-1459: expose schedules data

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -137,6 +137,7 @@ ScheduleType = type table [
     status = text,
     timezone = text,
     can_late_submit = logical,
+    site_id = nullable text,
     template_id = nullable text,
     creator_user_id = nullable text
 ];

--- a/iAuditor.query.pq
+++ b/iAuditor.query.pq
@@ -49,7 +49,7 @@ shared iAuditor.UnitTest =
         Fact("Inspections has 26 columns", 26, List.Count(Table.ColumnNames(GetInspections))),
 
         Fact("We have Schedules data?", true, not Table.IsEmpty(Schedules)),      
-        Fact("Schedules has 15 columns", 15, List.Count(Table.ColumnNames(Schedules))),
+        Fact("Schedules has 16 columns", 16, List.Count(Table.ColumnNames(Schedules))),
 
         Fact("We have Schedule Assignees data?", true, not Table.IsEmpty(ScheduleAssignees)),      
         Fact("Schedule Assignees has 5 columns", 5, List.Count(Table.ColumnNames(ScheduleAssignees))),


### PR DESCRIPTION
Make `Schedules` data available. This includes `schedules`, `schedule_assignees` and `schedule_occurrences` tables.