### PR TITLE
[INTG-1606] Add `item_index` column to `inspection_items` table

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -93,6 +93,7 @@ InspectionItemType = type table [
     id = text,
     item_id = text,
     audit_id = text,
+    item_index = number,
     template_id = text,
     parent_id = nullable text,
     created_at = datetimezone,


### PR DESCRIPTION
Power BI support multi columns sorts through the following M code

```
= Table.Sort(#"Changed Type",{{"Team", Order.Ascending}, {"Plan", Order.Descending}})
```