### PR TITLE
[INTG-1600] Add deleted flag to sites and optionally return deleted sites

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -130,7 +130,8 @@ SiteType = type table [
     id = text,
     name = text,
     creator_id = text,
-    organisation_id = text
+    organisation_id = text,
+    deleted = logical
 ];
 
 ScheduleType = type table [
@@ -268,6 +269,7 @@ CreateNavTable = (group as text) as table =>
                     {
                         [Name = "GetInspections", Data = Value.ReplaceType(GetInspections, GetInspectionsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
                         [Name = "GetInspectionItems", Data = Value.ReplaceType(GetInspectionItems, GetInspectionItemsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true]
+                        [Name = "GetSites", Data = Value.ReplaceType(GetSites, GetSitesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
                     },
                     type table[Name = Text.Type, Data = Function.Type, ItemKind = Text.Type, ItemName = Text.Type, IsLeaf = Logical.Type]
                 )
@@ -327,6 +329,14 @@ GetInspectionItems = (optional templateIds as text, optional modifiedAfter as da
     in
         table;
 
+GetSites = (optional includeDeleted as logical) as table =>
+    let
+        query = [],
+        withIncludeDeleted = if (includeDeleted <> null)  then Record.AddField(query, "include_deleted", Logical.ToText(includeDeleted)) else query,
+        table = GetEntity(Uri.Combine(BaseUrl, "/feed/"), "sites", withIncludeDeleted)
+    in
+        table;
+
 GetInspectionsType = type function (
     optional templateIds as (type text meta [
         Documentation.FieldCaption = "Template IDs",
@@ -380,6 +390,14 @@ GetInspectionItemsType = type function (
     optional includeInactive as (type logical meta [
         Documentation.FieldCaption = "Include Inactive",
         Documentation.FieldDescription = "Flag indicating should inactive inspection be included, or not",
+        Documentation.AllowedValues = { true, false }
+    ]))
+    as table;
+
+GetSitesType = type function (
+    optional includeDeleted as (type logical meta [
+        Documentation.FieldCaption = "Include Deleted",
+        Documentation.FieldDescription = "Flag indicating should deleted sites be included, or not",
         Documentation.AllowedValues = { true, false }
     ]))
     as table;

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -268,8 +268,8 @@ CreateNavTable = (group as text) as table =>
                 Table.FromRecords(
                     {
                         [Name = "GetInspections", Data = Value.ReplaceType(GetInspections, GetInspectionsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
-                        [Name = "GetInspectionItems", Data = Value.ReplaceType(GetInspectionItems, GetInspectionItemsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true]
-                        [Name = "GetSites", Data = Value.ReplaceType(GetSites, GetSitesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
+                        [Name = "GetInspectionItems", Data = Value.ReplaceType(GetInspectionItems, GetInspectionItemsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
+                        [Name = "GetSites", Data = Value.ReplaceType(GetSites, GetSitesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true]
                     },
                     type table[Name = Text.Type, Data = Function.Type, ItemKind = Text.Type, ItemName = Text.Type, IsLeaf = Logical.Type]
                 )

--- a/iAuditor.query.pq
+++ b/iAuditor.query.pq
@@ -13,6 +13,7 @@ shared iAuditor.UnitTest =
     TemplatePermissions = RootTable{[Name="template_permissions"]}[Data],
     Sites = RootTable{[Name="sites"]}[Data],
     GetInspections = RootTable{[Name="GetInspections"]}[Data](null, null, null, null, null),
+    GetSites = RootTable{[Name="GetSites"]}[Data](null),
 
     ScheduleFolder = RootTable{[Name="Schedule"]}[Data],
     Schedules = ScheduleFolder{[Name="schedules"]}[Data],
@@ -27,13 +28,13 @@ shared iAuditor.UnitTest =
     // <Expected Value> and <Actual Value> can be a literal or let statement
    facts =
    {
-       Fact("Check that we have the correct number of entries in our nav table", 11, Table.RowCount(RootTable)),
+       Fact("Check that we have the correct number of entries in our nav table", 13, Table.RowCount(RootTable)),
 
        Fact("We have Inspections data?", true, not Table.IsEmpty(Inspections)),
        Fact("Inspections has 27 columns", 27, List.Count(Table.ColumnNames(Inspections))),
 
         Fact("We have Inspection Items data?", true, not Table.IsEmpty(InspectionItems)),
-        Fact("Inspection Items has 25 columns", 25, List.Count(Table.ColumnNames(InspectionItems))),
+        Fact("Inspection Items has 26 columns", 26, List.Count(Table.ColumnNames(InspectionItems))),
 
         Fact("We have Users data?", true, not Table.IsEmpty(Users)),
         Fact("Users has 6 columns", 6, List.Count(Table.ColumnNames(Users))),
@@ -51,10 +52,13 @@ shared iAuditor.UnitTest =
         Fact("Template Permissions has 5 columns", 5, List.Count(Table.ColumnNames(TemplatePermissions))),
 
         Fact("We have Sites data?", true, not Table.IsEmpty(Sites)),
-        Fact("Templates has 4 columns", 4, List.Count(Table.ColumnNames(Sites))),
+        Fact("Sites has 5 columns", 5, List.Count(Table.ColumnNames(Sites))),
 
         Fact("We have GetInspections data?", true, not Table.IsEmpty(GetInspections)),
         Fact("Inspections has 27 columns", 27, List.Count(Table.ColumnNames(GetInspections))),
+
+        Fact("We have GetSites data?", true, not Table.IsEmpty(GetSites)),
+        Fact("Inspections has 5 columns", 5, List.Count(Table.ColumnNames(GetSites))),
 
         Fact("We have Schedules data?", true, not Table.IsEmpty(Schedules)),
         Fact("Schedules has 16 columns", 16, List.Count(Table.ColumnNames(Schedules))),


### PR DESCRIPTION
A new flag "Include Deleted Sites" has been added to GET feed/sites API which will return all locations/areas/regions(deleted and existing).
Default value of "Include Deleted Sites" = false.