### PR TITLE
INTG-1671: adding gateway support

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -11,9 +11,7 @@ iAuditor = [
         in
             { "iAuditor.Contents", orgName },
     Authentication = [
-        Key = [
-            Label = Extension.LoadString("TokenLabel")
-        ]
+        Key = []
     ],
     Label = Extension.LoadString("DataSourceLabel")
 ];

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -12,7 +12,7 @@ iAuditor = [
             { "iAuditor.Contents", orgName },
     Authentication = [
         Key = [
-            KeyLabel = Extension.LoadString("TokenLabel")
+            Label = Extension.LoadString("TokenLabel")
         ]
     ],
     Label = Extension.LoadString("DataSourceLabel")
@@ -20,7 +20,7 @@ iAuditor = [
 
 // Data Source UI publishing description
 iAuditor.Publish = [
-    Beta = true,
+    Beta = false,
     Category = "Other",
     ButtonText = { Extension.LoadString("ButtonTitle"), Extension.LoadString("ButtonHelp") },
     LearnMoreUrl = "https://github.com/SafetyCulture/iAuditor-Power-Query-Connector",

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -4,7 +4,12 @@ BaseUrl = "https://api.safetyculture.io";
 
 // Data Source Kind description
 iAuditor = [
-    TestConnection = (orgName) => {"iAuditor.Contents", orgName},
+    TestConnection = (dataSourcePath) =>
+        let
+            json = Json.Document(dataSourcePath),
+            orgName = json[orgName]
+        in
+            { "iAuditor.Contents", orgName },
     Authentication = [
         Key = [
             Label = Extension.LoadString("TokenLabel")

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -4,6 +4,7 @@ BaseUrl = "https://api.safetyculture.io";
 
 // Data Source Kind description
 iAuditor = [
+    TestConnection = (orgName) => {"iAuditor.Contents", orgName},
     Authentication = [
         Key = [
             Label = Extension.LoadString("TokenLabel")

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -11,7 +11,9 @@ iAuditor = [
         in
             { "iAuditor.Contents", orgName },
     Authentication = [
-        Key = []
+        Key = [
+            KeyLabel = Extension.LoadString("TokenLabel")
+        ]
     ],
     Label = Extension.LoadString("DataSourceLabel")
 ];
@@ -224,7 +226,19 @@ SchemaTable = #table({"Entity", "Type", "Group"}, {
 GetSchemaForEntity = (entity as text) as type => try SchemaTable{[Entity=entity]}[Type] otherwise error "Couldn't find entity: '" & entity &"'";
 
 [DataSource.Kind="iAuditor", Publish="iAuditor.Publish"]
-shared iAuditor.Contents = (orgName as text) as table => iAuditorNavTable();
+shared iAuditor.Contents = Value.ReplaceType(iAuditorImpl, iAuditorType);
+
+iAuditorType = type function (
+    orgName as (type text meta [
+        Documentation.FieldCaption = "Organization name",
+        Documentation.FieldDescription = "Name of your organization",
+        Documentation.SampleValues = {"ACME"}
+    ]))
+    as table meta [
+        Documentation.Name = "iAuditor by SafetyCulture"
+    ];
+
+iAuditorImpl = (orgName as text) as table => iAuditorNavTable();
 
 iAuditorNavTable = () as table =>
     let

--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -224,19 +224,7 @@ SchemaTable = #table({"Entity", "Type", "Group"}, {
 GetSchemaForEntity = (entity as text) as type => try SchemaTable{[Entity=entity]}[Type] otherwise error "Couldn't find entity: '" & entity &"'";
 
 [DataSource.Kind="iAuditor", Publish="iAuditor.Publish"]
-shared iAuditor.Contents = Value.ReplaceType(iAuditorImpl, iAuditorType);
-
-iAuditorType = type function (
-    orgName as (type text meta [
-        Documentation.FieldCaption = "Organization name",
-        Documentation.FieldDescription = "Name of your organization",
-        Documentation.SampleValues = {"ACME"}
-    ]))
-    as table meta [
-        Documentation.Name = "iAuditor by SafetyCulture"
-    ];
-
-iAuditorImpl = (orgName as text) as table => iAuditorNavTable();
+shared iAuditor.Contents = (orgName as text) as table => iAuditorNavTable();
 
 iAuditorNavTable = () as table =>
     let

--- a/resources.resx
+++ b/resources.resx
@@ -121,10 +121,10 @@
     <value>Connect to iAuditor</value>
   </data>
   <data name="ButtonTitle" xml:space="preserve">
-    <value>iAuditor by SafetyCulture Beta 2</value>
+    <value>iAuditor by SafetyCulture</value>
   </data>
   <data name="DataSourceLabel" xml:space="preserve">
-    <value>iAuditor by SafetyCulture Beta 2</value>
+    <value>iAuditor by SafetyCulture</value>
   </data>
   <data name="TokenLabel" xml:space="preserve">
     <value>iAuditor API Token</value>

--- a/resources.resx
+++ b/resources.resx
@@ -121,10 +121,10 @@
     <value>Connect to iAuditor</value>
   </data>
   <data name="ButtonTitle" xml:space="preserve">
-    <value>iAuditor by SafetyCulture</value>
+    <value>iAuditor by SafetyCulture Beta 2</value>
   </data>
   <data name="DataSourceLabel" xml:space="preserve">
-    <value>iAuditor by SafetyCulture</value>
+    <value>iAuditor by SafetyCulture Beta 2</value>
   </data>
   <data name="TokenLabel" xml:space="preserve">
     <value>iAuditor API Token</value>


### PR DESCRIPTION
These changes will allow our users to use `On-premises data gateway` which enables them to refresh their online dashboards on a schedule.
I deployed `On-premises data gateway` and tested these changes against Power BI online.