### PR TITLE
INTG-1919: add start_time and due_time for schedule occurrences

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -269,6 +269,8 @@ ScheduleOccurrenceType = type table [
     occurrence_id = text,
     user_id = text,
     template_id = text,
+    start_time = datetimezone,
+    due_time = datetimezone,
     miss_time = datetimezone,
     occurrence_status = text,
     assignee_status = text,
@@ -371,7 +373,8 @@ CreateNavTable = (group as text) as table =>
                     {
                         [Name = "GetInspections", Data = Value.ReplaceType(GetInspections, GetInspectionsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
                         [Name = "GetInspectionItems", Data = Value.ReplaceType(GetInspectionItems, GetInspectionItemsType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
-                        [Name = "GetSites", Data = Value.ReplaceType(GetSites, GetSitesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true]
+                        [Name = "GetSites", Data = Value.ReplaceType(GetSites, GetSitesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true],
+                        [Name = "GetScheduleOccurrences", Data = Value.ReplaceType(GetScheduleOccurrences, GetScheduleOccurrencesType), ItemKind = "Function", ItemName = "Function", IsLeaf = true]
                     },
                     type table[Name = Text.Type, Data = Function.Type, ItemKind = Text.Type, ItemName = Text.Type, IsLeaf = Logical.Type]
                 )
@@ -439,6 +442,16 @@ GetSites = (optional includeDeleted as logical) as table =>
     in
         table;
 
+GetScheduleOccurrences = (optional templateIds as text, optional startDate as datetimezone, optional endDate as datetimezone) as table =>
+    let
+        query = [],
+        withTemplateIds = if (templateIds <> null)  then Record.AddField(query, "template", Text.Split(templateIds, ",")) else query,
+        withStartDate = if (startDate <> null)  then Record.AddField(withTemplateIds, "start_date", DateTimeZone.ToText(startDate, "yyyy-MM-ddTHH:mm:ssZ")) else withTemplateIds,
+        withEndDate = if (endDate <> null)  then Record.AddField(withStartDate, "end_date", DateTimeZone.ToText(endDate, "yyyy-MM-ddTHH:mm:ssZ")) else withStartDate,
+        table = GetEntity(Uri.Combine(BaseUrl, "/feed/"), "schedule_occurrences", withEndDate)
+    in
+        table;
+
 GetInspectionsType = type function (
     optional templateIds as (type text meta [
         Documentation.FieldCaption = "Template IDs",
@@ -501,6 +514,22 @@ GetSitesType = type function (
         Documentation.FieldCaption = "Include Deleted",
         Documentation.FieldDescription = "Flag indicating should deleted sites be included, or not",
         Documentation.AllowedValues = { true, false }
+    ]))
+    as table;
+
+GetScheduleOccurrencesType = type function (
+    optional templateIds as (type text meta [
+        Documentation.FieldCaption = "Template IDs",
+        Documentation.FieldDescription = "Comma separated list of IDs of the template you want to load the schedule occurrences for",
+        Documentation.SampleValues = {"template_123,template_345"}
+    ]),
+    optional startDate as (type datetimezone meta [
+        Documentation.FieldCaption = "Start Date",
+        Documentation.FieldDescription = "Schedule occurrences have happened after this date (date range cannot exceed 6 months)"
+    ]),
+    optional endDate as (type datetimezone meta [
+        Documentation.FieldCaption = "End Date",
+        Documentation.FieldDescription = "Schedule occurrences have happened before this date (date range cannot exceed 6 months)"
     ]))
     as table;
 

--- a/iAuditor.query.pq
+++ b/iAuditor.query.pq
@@ -28,7 +28,7 @@ shared iAuditor.UnitTest =
     // <Expected Value> and <Actual Value> can be a literal or let statement
    facts =
    {
-       Fact("Check that we have the correct number of entries in our nav table", 13, Table.RowCount(RootTable)),
+       Fact("Check that we have the correct number of entries in our nav table", 14, Table.RowCount(RootTable)),
 
        Fact("We have Inspections data?", true, not Table.IsEmpty(Inspections)),
        Fact("Inspections has 27 columns", 27, List.Count(Table.ColumnNames(Inspections))),
@@ -67,7 +67,7 @@ shared iAuditor.UnitTest =
         Fact("Schedule Assignees has 5 columns", 5, List.Count(Table.ColumnNames(ScheduleAssignees))),
 
         Fact("We have Schedule Occurrences data?", true, not Table.IsEmpty(ScheduleOccurrences)),
-        Fact("Schedule Occurrences has 10 columns", 10, List.Count(Table.ColumnNames(ScheduleOccurrences))),
+        Fact("Schedule Occurrences has 12 columns", 12, List.Count(Table.ColumnNames(ScheduleOccurrences))),
 
         Fact("We have Actions data?", true, not Table.IsEmpty(Actions)),
         Fact("Schedules has 16 columns", 16, List.Count(Table.ColumnNames(Actions))),


### PR DESCRIPTION
## Changes made
- Added `start_time` and `due_time` to `schedule_occurrences`
- Added a new method called `GetScheduleOccurrences` that allows users to fetch data with a custom date range