### PR TITLE
[INTG-2204] add site_uuid column to site table

### DIFF
--- a/iAuditor.pq
+++ b/iAuditor.pq
@@ -245,7 +245,8 @@ SiteType = type table [
     name = text,
     creator_id = text,
     organisation_id = text,
-    deleted = logical
+    deleted = logical,
+    site_uuid = text
 ];
 
 ScheduleType = type table [
@@ -485,7 +486,7 @@ GetSites = (optional includeDeleted as logical) as table =>
 
 GetIssues = () as table =>
     let
-       query = [], 
+       query = [],
        table = GetEntity(Uri.Combine(BaseUrl, "/feed/"), "issues")
     in
         table;


### PR DESCRIPTION
Site feed will now include a site_uuid field. Adding a new `site_uuid` column to the site table